### PR TITLE
fix split folders files

### DIFF
--- a/image_helpers/split_folders_files.m
+++ b/image_helpers/split_folders_files.m
@@ -34,8 +34,7 @@ function [folders,files] = split_folders_files(input)
 %     end
 
 B = struct2cell(input); 
-B
-dirs = cell2mat(B(4,:)); 
+dirs = cell2mat(B(5,:)); 
 folders = input(logical(dirs)); 
 files = input(~logical(dirs));
 


### PR DESCRIPTION
should address #1

i have not tested this, but it is based on feedback from a user.
it is possible that the issue here is that different users have different paths?
if so, the hardwired number `4` or `5` is really the problem.
in any case, this change will alert users they might need to adjust the value here.